### PR TITLE
fix: 节流函数未执行导致dom元素未删除

### DIFF
--- a/components/like-button/like-button.vue
+++ b/components/like-button/like-button.vue
@@ -162,7 +162,7 @@
           // 逐渐消失
           if (this.alone) {
             this.waitDeleteIndex ++
-            this.onThrottle(this.deleteView, this.duration)
+            this.onThrottle(this.deleteView, this.duration)()
             return null;
           } else {
             // 完成动画后在n秒后清空
@@ -203,7 +203,7 @@
               // 逐渐消失
               if (this.alone) {
                 this.waitDeleteIndex ++
-                this.onThrottle(this.deleteView, this.duration)
+                this.onThrottle(this.deleteView, this.duration)()
                 return null
               } else {
                 // 完成动画后在n秒后清空


### PR DESCRIPTION
在**微信小程序**中发现点赞创建的**Dom节点**都**没有删除**
检查后 发现是 onThrottle 返回的函数没有调用